### PR TITLE
exceptions

### DIFF
--- a/Merlin/AcceleratorModel/AcceleratorGeometry.h
+++ b/Merlin/AcceleratorModel/AcceleratorGeometry.h
@@ -74,7 +74,7 @@ public:
 	* @exception Throws a BeyondExtent exception if the requested s values are outside the geometry extent.
 	* @return The 3D transformation from the entrance to the exit of this geometry.
 	*/
-	virtual Transform3D GetGeometryTransform(double s0, double s) const throw (BeyondExtent) = 0;
+	virtual Transform3D GetGeometryTransform(double s0, double s) const = 0;
 
 	/**
 	* Return the three-dimensional transformation from the
@@ -84,7 +84,7 @@ public:
 	* @exception Throws a BeyondExtent exception if the requested s value is outside the geometry extent.
 	* @return The 3D transformation from the entrance to the exit of this geometry.
 	*/
-	Transform3D GetGeometryTransform(double s) const throw (BeyondExtent);
+	Transform3D GetGeometryTransform(double s) const;
 
 	/**
 	* Returns the transformation from the geometry origin to
@@ -117,7 +117,7 @@ public:
 inline AcceleratorGeometry::~AcceleratorGeometry()
 {}
 
-inline Transform3D AcceleratorGeometry::GetGeometryTransform(double s) const throw (BeyondExtent)
+inline Transform3D AcceleratorGeometry::GetGeometryTransform(double s) const
 {
 	return GetGeometryTransform(0,s);
 }

--- a/Merlin/AcceleratorModel/AcceleratorModel.cpp
+++ b/Merlin/AcceleratorModel/AcceleratorModel.cpp
@@ -114,7 +114,7 @@ AcceleratorModel::Beamline AcceleratorModel::GetBeamline ()
 	return Beamline(lattice.begin(),i,0,lattice.size()-1);
 }
 
-AcceleratorModel::Beamline AcceleratorModel::GetBeamline (AcceleratorModel::Index n1, AcceleratorModel::Index n2) throw (BadRange)
+AcceleratorModel::Beamline AcceleratorModel::GetBeamline (AcceleratorModel::Index n1, AcceleratorModel::Index n2)
 {
 	if(n2>=lattice.size())
 	{
@@ -128,7 +128,7 @@ AcceleratorModel::Beamline AcceleratorModel::GetBeamline (AcceleratorModel::Inde
 	return Beamline(i1,i2,n1,n2);
 }
 
-AcceleratorModel::Beamline AcceleratorModel::GetBeamline (const string& pat1, const string& pat2, int n1, int n2) throw (BadRange)
+AcceleratorModel::Beamline AcceleratorModel::GetBeamline (const string& pat1, const string& pat2, int n1, int n2)
 {
 	assert(n1>=1 && n2>=1);
 

--- a/Merlin/AcceleratorModel/AcceleratorModel.h
+++ b/Merlin/AcceleratorModel/AcceleratorModel.h
@@ -262,7 +262,7 @@ public:
 	* @exception Throws a BadRange exception if the requested range cannot be found.
 	* @return The requested Beamline.
 	*/
-	Beamline GetBeamline(Index n1, Index n2) throw (BadRange);
+	Beamline GetBeamline(Index n1, Index n2);
 
 	/**
 	* Returns a Beamline from the n1-th occurrence of the
@@ -276,7 +276,7 @@ public:
 	* @exception Throws a BadRange exception if the requested range cannot be found.
 	* @return The requested Beamline.
 	*/
-	Beamline GetBeamline(const string& pat1, const string& pat2, int n1 = 1, int n2 = 1) throw (BadRange);
+	Beamline GetBeamline(const string& pat1, const string& pat2, int n1 = 1, int n2 = 1);
 
 	/**
 	* Assumes that the AcceleratorModel represents a ring

--- a/Merlin/AcceleratorModel/Frames/LatticeFrame.h
+++ b/Merlin/AcceleratorModel/Frames/LatticeFrame.h
@@ -138,11 +138,11 @@ public:
 
 	//	Returns the AcceleratorGeometry transformation from s0
 	//	to s (local s-frame).
-	Transform3D GetGeometryTransform (double s0, double s) const throw (AcceleratorGeometry::BeyondExtent);
+	Transform3D GetGeometryTransform (double s0, double s) const;
 
 	//	Returns the AcceleratorGeometry transformation from the
 	//	local origin to s (local s-frame).
-	Transform3D GetGeometryTransform (double s) const throw (AcceleratorGeometry::BeyondExtent);
+	Transform3D GetGeometryTransform (double s) const;
 
 	//	Returns the transformation from the origin to the
 	//	specified boundary plane.
@@ -308,7 +308,7 @@ inline double LatticeFrame::GetLocalPosition () const
 	return s_0;
 }
 
-inline Transform3D LatticeFrame::GetGeometryTransform (double s0, double s) const throw (AcceleratorGeometry::BeyondExtent)
+inline Transform3D LatticeFrame::GetGeometryTransform (double s0, double s) const
 {
 	if(itsGeometry!=0)
 	{
@@ -324,7 +324,7 @@ inline Transform3D LatticeFrame::GetGeometryTransform (double s0, double s) cons
 	}
 }
 
-inline Transform3D LatticeFrame::GetGeometryTransform (double s) const throw (AcceleratorGeometry::BeyondExtent)
+inline Transform3D LatticeFrame::GetGeometryTransform (double s) const
 {
 	if(itsGeometry!=0)
 	{

--- a/Merlin/AcceleratorModel/Frames/SequenceFrame.cpp
+++ b/Merlin/AcceleratorModel/Frames/SequenceFrame.cpp
@@ -40,7 +40,7 @@ public:
 	//	frame at s0 and the frame at s. s and s0 are in the
 	//	geometry's s-frame, and must be within the geometry
 	//	extents.
-	virtual Transform3D GetGeometryTransform (double s0, double s) const throw (BeyondExtent);
+	virtual Transform3D GetGeometryTransform (double s0, double s) const;
 
 	//	Returns the transformation from the geometry origin to
 	//	the specified boundary plane.
@@ -229,7 +229,7 @@ SequenceGeometry::~SequenceGeometry ()
 	}
 }
 
-Transform3D SequenceGeometry::GetGeometryTransform (double s0, double s) const throw (BeyondExtent)
+Transform3D SequenceGeometry::GetGeometryTransform (double s0, double s) const
 {
 	if(fequal(s,s0))
 	{

--- a/Merlin/AcceleratorModel/StdComponent/Monitor.cpp
+++ b/Merlin/AcceleratorModel/StdComponent/Monitor.cpp
@@ -32,7 +32,7 @@ Monitor::~Monitor ()
 void Monitor::MakeMeasurement (const Bunch& )
 {}
 
-void Monitor::SetMeasurementPt (double mpt) throw (AcceleratorGeometry::BeyondExtent)
+void Monitor::SetMeasurementPt (double mpt)
 {
 	//GetGeometry().CheckBounds(mpt); // might throw
 	mp=mpt;

--- a/Merlin/AcceleratorModel/StdComponent/Monitor.h
+++ b/Merlin/AcceleratorModel/StdComponent/Monitor.h
@@ -50,7 +50,7 @@ public:
 
 	//	Sets the position of the measurement point on the local
 	//	geometry. Must be in the range -length/2 to +length/2.
-	void SetMeasurementPt (double mpt) throw (AcceleratorGeometry::BeyondExtent);
+	void SetMeasurementPt (double mpt);
 
 	//	Return the current measurement point.
 	double GetMeasurementPt () const;

--- a/Merlin/AcceleratorModel/StdGeometry/ArcGeometry.cpp
+++ b/Merlin/AcceleratorModel/StdGeometry/ArcGeometry.cpp
@@ -25,7 +25,7 @@ inline Transform3D MakeTransform(double phi, double h)
 } // end annonymous namespace
 
 
-Transform3D ArcGeometry::GetGeometryTransform (double s0, double s) const throw (BeyondExtent)
+Transform3D ArcGeometry::GetGeometryTransform (double s0, double s) const
 {
 	CheckBounds(s,s0);
 	return MakeTransform((s-s0)*h,h);

--- a/Merlin/AcceleratorModel/StdGeometry/ArcGeometry.h
+++ b/Merlin/AcceleratorModel/StdGeometry/ArcGeometry.h
@@ -46,7 +46,7 @@ public:
 	double GetAngle () const;
 
 	//	Returns the arc transform from s0 to s (angle=h*(s-s0)).
-	virtual Transform3D GetGeometryTransform (double s0, double s) const throw (BeyondExtent);
+	virtual Transform3D GetGeometryTransform (double s0, double s) const;
 
 	//	Returns the arc transform for either -angle/2 or
 	//	+angle/2 for the entrance and exit planes respectively.

--- a/Merlin/AcceleratorModel/StdGeometry/CenteredGeometry.h
+++ b/Merlin/AcceleratorModel/StdGeometry/CenteredGeometry.h
@@ -38,10 +38,10 @@ public:
 protected:
 
 	//	Used to check if (s1s2) is within the geometry bounds.
-	void CheckBounds (double s1, double s2) const throw (BeyondExtent);
+	void CheckBounds (double s1, double s2) const;
 
 	//	Used to check if s1 is within the geometry bounds.
-	void CheckBounds (double s) const throw (BeyondExtent);
+	void CheckBounds (double s) const;
 
 	double len;
 };
@@ -61,7 +61,7 @@ inline AcceleratorGeometry::Extent CenteredGeometry::GetGeometryExtent () const
 	return Extent(-s,s);
 }
 
-inline void CenteredGeometry::CheckBounds (double s1, double s2) const throw (BeyondExtent)
+inline void CenteredGeometry::CheckBounds (double s1, double s2) const
 {
 	double hl=len/2;
 	if(fabs(s1)>hl || fabs(s2)>hl)
@@ -70,7 +70,7 @@ inline void CenteredGeometry::CheckBounds (double s1, double s2) const throw (Be
 	}
 }
 
-inline void CenteredGeometry::CheckBounds (double s) const throw (BeyondExtent)
+inline void CenteredGeometry::CheckBounds (double s) const
 {
 	if(fabs(s)>len/2)
 	{

--- a/Merlin/AcceleratorModel/StdGeometry/GeometryPatch.h
+++ b/Merlin/AcceleratorModel/StdGeometry/GeometryPatch.h
@@ -33,7 +33,7 @@ class GeometryPatch : public AcceleratorGeometry, public Transformable
 {
 public:
 
-	virtual Transform3D GetGeometryTransform (double s0, double s) const throw (BeyondExtent)
+	virtual Transform3D GetGeometryTransform (double s0, double s) const
 	{
 		if(s0!=0 || s!=0)
 		{

--- a/Merlin/AcceleratorModel/StdGeometry/RectangularGeometry.cpp
+++ b/Merlin/AcceleratorModel/StdGeometry/RectangularGeometry.cpp
@@ -14,7 +14,7 @@
 
 #include "AcceleratorModel/StdGeometry/RectangularGeometry.h"
 
-Transform3D RectangularGeometry::GetGeometryTransform (double s0, double s) const throw (BeyondExtent)
+Transform3D RectangularGeometry::GetGeometryTransform (double s0, double s) const
 {
 	CheckBounds(s,s0);
 	return Transform3D::translation(0,0,s-s0);

--- a/Merlin/AcceleratorModel/StdGeometry/RectangularGeometry.h
+++ b/Merlin/AcceleratorModel/StdGeometry/RectangularGeometry.h
@@ -31,7 +31,7 @@ public:
 	RectangularGeometry (double l);
 
 	//	Returns a translation along the z-axis of (s-s0).
-	virtual Transform3D GetGeometryTransform (double s0, double s) const throw (BeyondExtent);
+	virtual Transform3D GetGeometryTransform (double s0, double s) const;
 
 	//	Returns a translation along the z-axis of either +l/2 or
 	//	-l/2 for the entrance and exit boundary planes

--- a/Merlin/NumericalUtils/Interpolation.cpp
+++ b/Merlin/NumericalUtils/Interpolation.cpp
@@ -36,7 +36,7 @@ public:
 	};
 
 	ArbSpacedData(const vector<double>& xvals, const vector<double>& yvals);
-	virtual double ValueAt(double) const throw(Interpolation::BadRange);
+	virtual double ValueAt(double) const;
 
 private:
 	vector<Data> itsData;
@@ -54,7 +54,7 @@ public:
 		assert(dx>0);
 	}
 
-	double ValueAt(double x) const throw(Interpolation::BadRange);
+	double ValueAt(double x) const;
 
 private:
 	vector<double> yvals;
@@ -84,7 +84,7 @@ ArbSpacedData::ArbSpacedData(const vector<double>& xvals, const vector<double>& 
 	sort(itsData.begin(),itsData.end(),sort_x);
 }
 
-double ArbSpacedData::ValueAt(double x) const throw (Interpolation::BadRange)
+double ArbSpacedData::ValueAt(double x) const
 {
 	if(x<itsData.front().x || x>itsData.back().x)
 	{
@@ -115,7 +115,7 @@ double ArbSpacedData::ValueAt(double x) const throw (Interpolation::BadRange)
 // Class EqualSpacedData implementation
 //
 
-double EqualSpacedData::ValueAt(double x) const throw(Interpolation::BadRange)
+double EqualSpacedData::ValueAt(double x) const
 {
 	// note that we use extrapolation here if x is out of range
 	size_t n;

--- a/Merlin/NumericalUtils/Interpolation.h
+++ b/Merlin/NumericalUtils/Interpolation.h
@@ -42,7 +42,7 @@ public:
 	{
 	public:
 		virtual ~Method() {}
-		virtual double ValueAt(double x) const throw (BadRange) =0;
+		virtual double ValueAt(double x) const = 0;
 	};
 
 	// Interpolation of equally spaced data points
@@ -53,7 +53,7 @@ public:
 
 	~Interpolation();
 
-	double operator()(double x) const throw (BadRange)
+	double operator()(double x) const
 	{
 		return itsMethod->ValueAt(x);
 	}

--- a/Merlin/TLAS/TLASimp.h
+++ b/Merlin/TLAS/TLASimp.h
@@ -37,7 +37,7 @@ public:
 	// Construction from an arbitrary (square) matrix.
 	// Throws DimensionError() if the matrix is not square, or
 	// SingularMatrix() if the matrix is singular.
-	explicit LUMatrix(const Matrix<T>& M) throw (DimensionError, SingularMatrix)
+	explicit LUMatrix(const Matrix<T>& M)
 		: lud(M),indecies(),d(1)
 	{
 		ludcmp(lud,indecies,d);
@@ -103,8 +103,8 @@ public:
 	// made square by the addition of M.ncols()-M.nrows() zero rows. threshold specifies
 	// the relative (to the largest singular value) threshold value below which the
 	// singular values are set to zero.
-	explicit SVDMatrix(const Matrix<T>& M, T threshold = T(1e-06)) throw (ConvergenceFailure,SingularValuesAllZero);
-	SVDMatrix(const Matrix<T>& M, const Vector<T>& wts, T threshold = T(1e-06)) throw (ConvergenceFailure,SingularValuesAllZero);
+	explicit SVDMatrix(const Matrix<T>& M, T threshold = T(1e-06));
+	SVDMatrix(const Matrix<T>& M, const Vector<T>& wts, T threshold = T(1e-06));
 
 	// Solve the RHS vector using this SVD.
 	Vector<T> operator()(const Vector<T>& rhs) const
@@ -158,7 +158,7 @@ private:
 };
 
 template<class T>
-SVDMatrix<T>::SVDMatrix(const Matrix<T>& M, T threshold) throw (ConvergenceFailure, SingularValuesAllZero)
+SVDMatrix<T>::SVDMatrix(const Matrix<T>& M, T threshold)
 	: wts(M.nrows())
 {
 	wts=T(1);
@@ -167,7 +167,6 @@ SVDMatrix<T>::SVDMatrix(const Matrix<T>& M, T threshold) throw (ConvergenceFailu
 
 template<class T>
 SVDMatrix<T>::SVDMatrix(const Matrix<T>& M, const Vector<T>& wts1, T threshold)
-throw (ConvergenceFailure, SingularValuesAllZero)
 	: wts(M.nrows())
 {
 	wts=wts1;


### PR DESCRIPTION
Having function exception specifications i.e. throw() is depreciated in c++11 and super verboten in c++17. Functions should just be marked as nothrow if they won't ever throw instead.

I removed all of these.

This fixes building with gcc 7.

