### PR TITLE
Increase test timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,16 +199,19 @@ if(BUILD_STATIC)
 	add_library(merlin STATIC ${sources})
 endif()
 
+
+
 IF(COVERAGE)
+	set(COVERAGE_FLAGS "-fprofile-arcs")
 	target_compile_options(merlin PRIVATE -fprofile-arcs -ftest-coverage)
-	SET_TARGET_PROPERTIES(merlin PROPERTIES LINK_FLAGS "-fprofile-arcs ${CMAKE_EXE_LINKER_FLAGS}")
+	SET_TARGET_PROPERTIES(merlin PROPERTIES LINK_FLAGS " ${COVERAGE_FLAGS} ${CMAKE_EXE_LINKER_FLAGS}")
 ENDIF(COVERAGE)
 
 #We want to link to the mpi libraries if this is an MPI build.
 if(CMAKE_BUILD_TYPE STREQUAL MPI OR CMAKE_BUILD_TYPE STREQUAL MPIDEBUG)
 	#Add in linker and compile flags
 	SET_TARGET_PROPERTIES(merlin PROPERTIES COMPILE_FLAGS "${MPI_CXX_COMPILE_FLAGS}")
-	SET_TARGET_PROPERTIES(merlin PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
+	SET_TARGET_PROPERTIES(merlin PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS} ${COVERAGE_FLAGS}")
 	#and the lib link
 	target_link_libraries(merlin ${MPI_CXX_LIBRARIES})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ OPTION(INSTALL_HEADERS "Install the Merlin headers. Default OFF" OFF)
 OPTION(LIBNUMA "Link to libnuma. See utility/CPUFeatures.h Default OFF" OFF)
 OPTION(ENABLE_ROOT "Build the Root output example. Default OFF" OFF)
 OPTION(COVERAGE "Enable build flags for testing code coverage with gcov (only works with GNU compilers)" OFF)
+SET(TEST_TIMEOUT "7200" CACHE STRING "Time allowed per test (seconds)")
 
 #Set the default build type
 if(NOT CMAKE_BUILD_TYPE)

--- a/MerlinTests/CMakeLists.txt
+++ b/MerlinTests/CMakeLists.txt
@@ -27,6 +27,11 @@ macro (merlin_test_py dir script_name)
 	                   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${dir}/${script_name} ${CMAKE_CURRENT_BINARY_DIR}/${dir}/${script_name})
 endmacro (merlin_test_py)
 
+# test with an extended timeout
+macro (add_test_t name)
+	add_test(${name} ${ARGN})
+	set_tests_properties(${name} PROPERTIES TIMEOUT ${TEST_TIMEOUT})
+endmacro (add_test_t)
 
 add_custom_target(TestDataFiles ALL)
 add_custom_command(TARGET TestDataFiles
@@ -36,38 +41,38 @@ add_custom_command(TARGET TestDataFiles
                    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/outputs)
 
 merlin_test_py(BasicTests have_python.py)
-add_test(have_python BasicTests/have_python.py)
+add_test_t(have_python BasicTests/have_python.py)
 
 merlin_test(BasicTests bunch_test bunch_test.cpp)
-add_test(bunch_test BasicTests/bunch_test)
+add_test_t(bunch_test BasicTests/bunch_test)
 
 merlin_test(BasicTests landau_test landau_test.cpp)
 merlin_test_py(BasicTests landau_test.py)
-add_test(landau_test.py BasicTests/landau_test.py)
+add_test_t(landau_test.py BasicTests/landau_test.py)
 
 merlin_test(BasicTests aperture_test aperture_test.cpp)
-add_test(aperture_test BasicTests/aperture_test)
+add_test_t(aperture_test BasicTests/aperture_test)
 
 merlin_test(BasicTests collimate_particle_process_test collimate_particle_process_test.cpp)
-add_test(collimate_particle_process_test BasicTests/collimate_particle_process_test)
+add_test_t(collimate_particle_process_test BasicTests/collimate_particle_process_test)
 
 merlin_test(OpticsTests lhc_optics_test lhc_optics_test.cpp)
-add_test(lhc_optics_test OpticsTests/lhc_optics_test)
+add_test_t(lhc_optics_test OpticsTests/lhc_optics_test)
 
 merlin_test(OpticsTests lhc_fft_tune_test lhc_fft_tune_test.cpp)
-add_test(lhc_fft_tune_test OpticsTests/lhc_fft_tune_test)
+add_test_t(lhc_fft_tune_test OpticsTests/lhc_fft_tune_test)
 
 merlin_test(ScatteringTests cu50_test cu50_test.cpp)
 merlin_test_py(ScatteringTests cu50_test.py)
-add_test(cu50_test.py_1e7 ScatteringTests/cu50_test.py 0 10000000)
-add_test(cu50_test.py_1e7_sixtrack ScatteringTests/cu50_test.py 0 10000000 sixtrack)
-#add_test(cu50_test.py_1e8 ScatteringTests/cu50_test.py 0 100000000) # more thorough test
-#add_test(cu50_test.py_1e8_sixtrack ScatteringTests/cu50_test.py 0 100000000 sixtrack) # more thorough test
+add_test_t(cu50_test.py_1e7 ScatteringTests/cu50_test.py 0 10000000)
+add_test_t(cu50_test.py_1e7_sixtrack ScatteringTests/cu50_test.py 0 10000000 sixtrack)
+#add_test_t(cu50_test.py_1e8 ScatteringTests/cu50_test.py 0 100000000) # more thorough test
+#add_test_t(cu50_test.py_1e8_sixtrack ScatteringTests/cu50_test.py 0 100000000 sixtrack) # more thorough test
 
 merlin_test(ScatteringTests lhc_collimation_test lhc_collimation_test.cpp)
 merlin_test_py(ScatteringTests lhc_collimation_test.py)
-add_test(lhc_collimation_test.py_1e4 ScatteringTests/lhc_collimation_test.py 0 10000)
-#add_test(lhc_collimation_test.py_1e5 ScatteringTests/lhc_collimation_test.py 0 100000)
+add_test_t(lhc_collimation_test.py_1e4 ScatteringTests/lhc_collimation_test.py 0 10000)
+#add_test_t(lhc_collimation_test.py_1e5 ScatteringTests/lhc_collimation_test.py 0 100000)
 
 merlin_test(ScatteringTests rand_test rand_test.cpp)
 


### PR DESCRIPTION
Some test take longer than the default timeout, especially on slow
machines like a RaspberryPi. Increase the timeout to 2 hours per test,
controllable by the TEST_TIMEOUT option.