### PR TITLE
Remove erf and erfc

### DIFF
--- a/Merlin/NumericalUtils/erfcc.cpp
+++ b/Merlin/NumericalUtils/erfcc.cpp
@@ -17,20 +17,6 @@
 
 using namespace std;
 
-// Error function and complimentry error function
-// Taken for NRiC (and modified)
-
-double erfc(double x)
-{
-	double t,z,ans;
-	z=fabs(x);
-	t=1.0/(1.0+0.5*z);
-	ans=t*exp(-z*z-1.26551223+t*(1.00002368+t*(0.37409196+t*(0.09678418+
-	                             t*(-0.18628806+t*(0.27886807+t*(-1.13520398+t*(1.48851587+
-	                                     t*(-0.82215223+t*0.17087277)))))))));
-	return  x >= 0.0 ? ans : 2.0-ans;
-}
-
 double NormalBin(double x1, double x2)
 {
 	static const double root2 = sqrt(2.0);

--- a/Merlin/NumericalUtils/utils.h
+++ b/Merlin/NumericalUtils/utils.h
@@ -41,13 +41,6 @@ OS<<"done: real time: "<<int(difftime(time(0),start_t))<<" seconds"<<endl;}
 // special function definitions
 // ----------------------------
 
-// Error function
-double erfc(double x);
-inline double erf(double x)
-{
-	return 1-erfc(x);
-}
-
 double NormalBin(double x1, double x2);
 
 // Modified Bessel function


### PR DESCRIPTION
These are now standard functions in C++11. Redefinition causes build
errors in some cases. See PR #18