### PR TITLE
Fixes and clean up to MonitorProcess

### DIFF
--- a/Merlin/BeamDynamics/ParticleTracking/MonitorProcess.h
+++ b/Merlin/BeamDynamics/ParticleTracking/MonitorProcess.h
@@ -8,17 +8,34 @@
 
 namespace ParticleTracking
 {
+/**
+ * A process for recording particle coordinates at elements
+ *
+ * Can be attached to the tracker to record particle coordinates at all
+ * or specific elements to files.
+ */
 class MonitorProcess : public ParticleBunchProcess
 {
-public:
-
+private:
 	vector<string> dump_at_elements;
 	string file_prefix;
-
 	unsigned int count;
 
+public:
+	/**
+	 * Create a MonitorProcess
+	 *
+	 * \param aID Process ID
+	 * \param prio Process priority
+	 * \param prefix Output file name prefix
+	 *
+	 */
 	MonitorProcess(const string& aID = "MONITOR",  int prio=0, const string& prefix = "");
+
+	/// Set the output file name prefix
 	void SetPrefix(const string& prefix);
+
+	/// Add element at which to record
 	void AddElement(const string e);
 	void InitialiseProcess (Bunch&  bunch);
 	void DoProcess (const double ds);


### PR DESCRIPTION
Make MonitorProcess only record at requested elements.
Use component name in filename
Clean up element check
Remove commented out code
Add some documentation
Cleanup MPI part
Make variables private