### PR TITLE
HEL AC mode: step by TuneVarPerStep

### DIFF
--- a/Merlin/HollowELensProcess.cpp
+++ b/Merlin/HollowELensProcess.cpp
@@ -142,7 +142,7 @@ void HollowELensProcess::DoProcess (double /*ds*/)
 					double OpTune;
 					if( (TuneVarPerStep !=0) && (DeltaTune !=0) )
 					{
-						OpTune = MinTune + fmod((floor(Turn/TurnsPerStep)),(Nstep));
+						OpTune = MinTune + fmod((floor(Turn/TurnsPerStep)),(Nstep)) * TuneVarPerStep;
 					}
 					else
 					{


### PR DESCRIPTION
Fix bug. Step should be by TuneVarPerStep, before was effectiving
staying on MinTine.