### PR TITLE
Sam new bunch constructor

### DIFF
--- a/Merlin/ElectronBunch.h
+++ b/Merlin/ElectronBunch.h
@@ -41,6 +41,9 @@ public:
 	ElectronBunch (double P0, double Qm = 1)
 		: ParticleBunch(P0, Qm) {};
 
+	ElectronBunch (size_t np, const ParticleDistributionGenerator & generator, const BeamData& beam, ParticleBunchFilter* filter = nullptr)
+		: ParticleBunch(np, generator, beam, filter) {};
+
 	virtual bool IsStable() const;
 	virtual double GetParticleMass() const;
 	virtual double GetParticleMassMeV() const;

--- a/Merlin/HaloParticleDistributionGenerator.cpp
+++ b/Merlin/HaloParticleDistributionGenerator.cpp
@@ -1,0 +1,55 @@
+#include "HaloParticleDistributionGenerator.h"
+#include "RandomNG.h"
+#include "NumericalConstants.h"
+
+PSvector HorizonalHalo1ParticleDistributionGenerator::GenerateFromDistribution() const
+{
+	PSvector p(0);
+	double u = RandomNG::uniform(-pi,pi);
+	p.x()    = cos(u) * sqrt(halo_size);
+	p.xp()   = sin(u) * sqrt(halo_size);
+	p.y()    = 0.0;
+	p.yp()   = 0.0;
+	p.dp()   = RandomNG::uniform(-1,1);
+	p.ct()   = RandomNG::uniform(-1,1);
+	return p;
+}
+
+PSvector VerticalHalo1ParticleDistributionGenerator::GenerateFromDistribution() const
+{
+	PSvector p(0);
+	double u = RandomNG::uniform(-pi,pi);
+	p.x()    = 0.0;
+	p.xp()   = 0.0;
+	p.y()    = cos(u) * sqrt(halo_size);
+	p.yp()   = sin(u) * sqrt(halo_size);
+	p.dp()   = RandomNG::uniform(-1,1);
+	p.ct()   = RandomNG::uniform(-1,1);
+	return p;
+}
+
+PSvector HorizonalHalo2ParticleDistributionGenerator::GenerateFromDistribution() const
+{
+	PSvector p(0);
+	double u = RandomNG::uniform(-pi,pi);
+	p.x()    = cos(u) * sqrt(halo_size);
+	p.xp()   = sin(u) * sqrt(halo_size);
+	p.y()    = RandomGauss(1,cutoffs.y());
+	p.yp()   = RandomGauss(1,cutoffs.yp());
+	p.dp()   = RandomNG::uniform(-1,1);
+	p.ct()   = RandomNG::uniform(-1,1);
+	return p;
+}
+
+PSvector VerticalHalo2ParticleDistributionGenerator::GenerateFromDistribution() const
+{
+	PSvector p(0);
+	double u = RandomNG::uniform(-pi,pi);
+	p.x()    = RandomGauss(1,cutoffs.x());
+	p.xp()   = RandomGauss(1,cutoffs.xp());
+	p.y()    = cos(u) * sqrt(halo_size);
+	p.yp()   = sin(u) * sqrt(halo_size);
+	p.dp()   = RandomNG::uniform(-1,1);
+	p.ct()   = RandomNG::uniform(-1,1);
+	return p;
+}

--- a/Merlin/HaloParticleDistributionGenerator.h
+++ b/Merlin/HaloParticleDistributionGenerator.h
@@ -1,0 +1,74 @@
+#ifndef HaloParticleDistributionGenerator_h
+#define HaloParticleDistributionGenerator_h 1
+
+#include "PSvector.h"
+#include "ParticleDistributionGenerator.h"
+
+class Halo1ParticleDistributionGenerator: public ParticleDistributionGenerator
+{
+public:
+	/// @parameter halo_size_ Size of halo in units of sigma
+	Halo1ParticleDistributionGenerator(double halo_size_ = 1.0):halo_size(halo_size_) {}
+protected:
+	double halo_size;
+};
+
+/**
+ * Generator for a horizontal halo distribution.
+ *
+ * Particles in a ring in x, x' at amplitude of halo_size_ sigma. Particles on 0,0 in y, y'
+ */
+class HorizonalHalo1ParticleDistributionGenerator: public Halo1ParticleDistributionGenerator
+{
+public:
+	using Halo1ParticleDistributionGenerator::Halo1ParticleDistributionGenerator;
+	virtual PSvector GenerateFromDistribution() const override;
+};
+
+/**
+ * Generator for a vertical halo distribution.
+ *
+ * Particles in a ring in y, y' at amplitude of halo_size_ sigma. Particles on 0,0 in x, x'
+ */
+class VerticalHalo1ParticleDistributionGenerator: public Halo1ParticleDistributionGenerator
+{
+public:
+	using Halo1ParticleDistributionGenerator::Halo1ParticleDistributionGenerator;
+	virtual PSvector GenerateFromDistribution() const override;
+};
+
+class Halo2ParticleDistributionGenerator: public ParticleDistributionGenerator
+{
+public:
+	Halo2ParticleDistributionGenerator(double halo_size_ = 1.0, PSvector cutoffs_ = PSvector(0)):halo_size(halo_size_), cutoffs(cutoffs_) {}
+	Halo2ParticleDistributionGenerator(PSvector cutoffs_):halo_size(1.0), cutoffs(cutoffs_) {}
+protected:
+	double halo_size;
+	PSvector cutoffs;
+};
+
+/**
+ * Generator for a horizontal halo distribution.
+ *
+ * Particles in a ring in x, x' at amplitude of halo_size_ sigma. Particles normally distributed y, y'
+ */
+class HorizonalHalo2ParticleDistributionGenerator: public Halo2ParticleDistributionGenerator
+{
+public:
+	using Halo2ParticleDistributionGenerator::Halo2ParticleDistributionGenerator;
+	virtual PSvector GenerateFromDistribution() const override;
+};
+
+/**
+ * Generator for a vertical halo distribution.
+ *
+ * Particles in a ring in y, y' at amplitude of halo_size_ sigma. Particles normally distributed in x, x'
+ */
+class VerticalHalo2ParticleDistributionGenerator: public Halo2ParticleDistributionGenerator
+{
+public:
+	using Halo2ParticleDistributionGenerator::Halo2ParticleDistributionGenerator;
+	virtual PSvector GenerateFromDistribution() const override;
+};
+
+#endif

--- a/Merlin/MuonBunch.h
+++ b/Merlin/MuonBunch.h
@@ -35,6 +35,9 @@ public:
 	*/
 	MuonBunch (double P0, double Qm = 1) : ParticleBunch(P0, Qm) {};
 
+	MuonBunch (size_t np, const ParticleDistributionGenerator & generator, const BeamData& beam, ParticleBunchFilter* filter = nullptr)
+		: ParticleBunch(np, generator, beam, filter) {};
+
 	virtual bool IsStable() const;
 	virtual double GetParticleMass() const;
 	virtual double GetParticleMassMeV() const;

--- a/Merlin/ParticleBunch.cpp
+++ b/Merlin/ParticleBunch.cpp
@@ -21,6 +21,9 @@
 #include "ParticleBunch.h"
 #include "NormalTransform.h"
 #include "MatrixMaps.h"
+#include "ParticleDistributionGenerator.h"
+#include "BeamData.h"
+#include "BunchFilter.h"
 
 #ifdef MERLIN_PROFILE
 #include "MerlinProfile.h"

--- a/Merlin/ParticleBunch.cpp
+++ b/Merlin/ParticleBunch.cpp
@@ -374,19 +374,27 @@ void ParticleBunch::Input (double Q, std::istream& is)
 	qPerMP = Q/size();
 }
 
-
-
-void ParticleBunch::SetCentroid (const Particle& x0)
+void ParticleBunch::SetCentroid ()
 {
 	PSvector x;
 	GetCentroid(x);
-	x-=x0;
-	for(PSvectorArray::iterator p = begin(); p!=end(); p++)
+	x-=FirstParticle();
+	for(PSvectorArray::iterator p = begin()+1; p!=end(); p++)
 	{
-		*p-=x;
+		p->x() -= x.x();
+		p->xp() -= x.xp();
+		p->y() -= x.y();
+		p->yp() -= x.yp();
+		p->dp() -= x.dp();
+		p->ct() -= x.ct();
 	}
 }
 
+void ParticleBunch::SetCentroid (const Particle& x0)
+{
+	FirstParticle() = x0;
+	SetCentroid();
+}
 
 bool ParticleBunch::IsStable() const
 {

--- a/Merlin/ParticleBunch.cpp
+++ b/Merlin/ParticleBunch.cpp
@@ -159,8 +159,8 @@ ParticleBunch::ParticleBunch (double P0, double Qm)
 	: Bunch(P0,Qm),init(false),coords((int) sizeof(PSvector)/sizeof(double)),ScatteringPhysicsModel(0),qPerMP(Qm)
 {}
 
-ParticleBunch::ParticleBunch (double P0, double Q, size_t np, const ParticleDistributionGenerator& generator, const BeamData& beam, ParticleBunchFilter* filter)
-	:ParticleBunch(P0,Q)
+ParticleBunch::ParticleBunch (size_t np, const ParticleDistributionGenerator& generator, const BeamData& beam, ParticleBunchFilter* filter)
+	:ParticleBunch(beam.p0,beam.charge)
 {
 	RMtrx M;
 	M.R = NormalTransform(beam);

--- a/Merlin/ParticleBunch.cpp
+++ b/Merlin/ParticleBunch.cpp
@@ -132,16 +132,14 @@ inline void SortArray(std::list<T>& array)
 namespace ParticleTracking
 {
 
-ParticleBunch::ParticleBunch (double P0, double Q, PSvectorArray& particles, double ParticleMass, double ParticleMassMeV, double ParticleLifetime)
+ParticleBunch::ParticleBunch (double P0, double Q, PSvectorArray& particles)
 	: Bunch(P0,Q),init(false),coords((int) sizeof(PSvector)/sizeof(double)),ScatteringPhysicsModel(0),qPerMP(Q/particles.size()),pArray()
-	  //, ParticleMass(ParticleMass), ParticleMassMeV(ParticleMassMeV), ParticleLifetime(ParticleLifetime)
 {
 	pArray.swap(particles);
 }
 
-ParticleBunch::ParticleBunch (double P0, double Q, std::istream& is, double ParticleMass, double ParticleMassMeV, double ParticleLifetime)
+ParticleBunch::ParticleBunch (double P0, double Q, std::istream& is)
 	: Bunch(P0,Q),init(false),coords((int) sizeof(PSvector)/sizeof(double)),ScatteringPhysicsModel(0)
-	  //, ParticleMass(ParticleMass), ParticleMassMeV(ParticleMassMeV), ParticleLifetime(ParticleLifetime)
 {
 	PSvector p;
 	while(is>>p)
@@ -152,9 +150,8 @@ ParticleBunch::ParticleBunch (double P0, double Q, std::istream& is, double Part
 	qPerMP = Q/size();
 }
 
-ParticleBunch::ParticleBunch (double P0, double Qm, double ParticleMass, double ParticleMassMeV, double ParticleLifetime)
+ParticleBunch::ParticleBunch (double P0, double Qm)
 	: Bunch(P0,Qm),init(false),coords((int) sizeof(PSvector)/sizeof(double)),ScatteringPhysicsModel(0),qPerMP(Qm)
-	  //, ParticleMass(ParticleMass), ParticleMassMeV(ParticleMassMeV), ParticleLifetime(ParticleLifetime)
 {}
 
 double ParticleBunch::GetTotalCharge () const
@@ -345,13 +342,11 @@ bool ParticleBunch::IsStable() const
 
 double ParticleBunch::GetParticleMass() const
 {
-//	return ElectronMass;
 	return 0;
 }
 
 double ParticleBunch::GetParticleMassMeV() const
 {
-//	return ElectronMassMeV;
 	return 0;
 }
 
@@ -359,7 +354,6 @@ double ParticleBunch::GetParticleLifetime() const
 {
 	return 0;
 }
-
 
 
 //MPI code

--- a/Merlin/ParticleBunch.h
+++ b/Merlin/ParticleBunch.h
@@ -54,19 +54,19 @@ public:
 	*	total charge and the particle array. Note that on exit,
 	*	particles is empty.
 	*/
-	ParticleBunch (double P0, double Q, PSvectorArray& particles, double ParticleMass = ElectronMass, double ParticleMassMeV = ElectronMassMeV, double ParticleLifetime = -1);
+	ParticleBunch (double P0, double Q, PSvectorArray& particles);
 
 	/**
 	*	Read phase space vectors from specified input stream.
 	*/
-	ParticleBunch (double P0, double Q, std::istream& is, double ParticleMass = ElectronMass, double ParticleMassMeV = ElectronMassMeV, double ParticleLifetime = -1);
+	ParticleBunch (double P0, double Q, std::istream& is);
 
 	/**
 	*	Constructs an empty ParticleBunch with the specified
 	*	momentum P0 and charge per macro particle Qm (default =
 	*	+1).
 	*/
-	ParticleBunch (double P0, double Qm = 1, double ParticleMass = ElectronMass, double ParticleMassMeV = ElectronMassMeV, double ParticleLifetime = -1);
+	ParticleBunch (double P0, double Qm = 1);
 
 	/**
 	*	Returns the total charge (in units of e).

--- a/Merlin/ParticleBunch.h
+++ b/Merlin/ParticleBunch.h
@@ -19,10 +19,10 @@
 #include "PSTypes.h"
 #include "Bunch.h"
 #include "PhysicalConstants.h"
-#include "Aperture.h"
-#include "ParticleDistributionGenerator.h"
-#include "BeamData.h"
-#include "BunchFilter.h"
+
+class Aperture; //#include "Aperture.h"
+class ParticleDistributionGenerator; //#include "ParticleDistributionGenerator.h"
+class BeamData; //#include "BeamData.h"
 
 #ifdef ENABLE_MPI
 #include <mpi.h>
@@ -34,7 +34,7 @@ using namespace PhysicalConstants;
 
 namespace ParticleTracking
 {
-
+class ParticleBunchFilter; //#include "BunchFilter.h"
 /**
 *	Representation of a particle.
 */

--- a/Merlin/ParticleBunch.h
+++ b/Merlin/ParticleBunch.h
@@ -79,7 +79,7 @@ public:
 	* using an optional ParticleBunchFilter.
 	*/
 
-	ParticleBunch (double P0, double Q, size_t np, const ParticleDistributionGenerator & generator, const BeamData& beam, ParticleBunchFilter* filter = nullptr);
+	ParticleBunch (size_t np, const ParticleDistributionGenerator & generator, const BeamData& beam, ParticleBunchFilter* filter = nullptr);
 
 	/**
 	*	Returns the total charge (in units of e).

--- a/Merlin/ParticleBunch.h
+++ b/Merlin/ParticleBunch.h
@@ -43,6 +43,8 @@ typedef PSvector Particle;
 /**
 *	A Bunch which is represented by an ensemble of
 *	(macro-)particles.
+*
+*	The first particle in the bunch is the centroid.
 */
 class ParticleBunch : public Bunch
 {
@@ -175,7 +177,14 @@ public:
 	Particle& FirstParticle ();
 
 	/**
-	*	Sets the centroid of the particle bunch to be exactly x0.
+	* Sets the centroid of the particle bunch to be equal to the zeroth
+	* particle, by moving each coordinate by the required amount.
+	*/
+	void SetCentroid ();
+
+	/**
+	* Sets the centroid of the particle bunch to be exactly x0 and updates
+	* the zeroth particle to x0.
 	*/
 	void SetCentroid (const Particle& x0);
 

--- a/Merlin/ParticleBunch.h
+++ b/Merlin/ParticleBunch.h
@@ -20,6 +20,9 @@
 #include "Bunch.h"
 #include "PhysicalConstants.h"
 #include "Aperture.h"
+#include "ParticleDistributionGenerator.h"
+#include "BeamData.h"
+#include "BunchFilter.h"
 
 #ifdef ENABLE_MPI
 #include <mpi.h>
@@ -67,6 +70,14 @@ public:
 	*	+1).
 	*/
 	ParticleBunch (double P0, double Qm = 1);
+
+	/**
+	* Constructs an ParticleBunch with coordinates generated from a
+	* random distribution matched to a beam. Particles can be filtered
+	* using an optional ParticleBunchFilter.
+	*/
+
+	ParticleBunch (double P0, double Q, size_t np, const ParticleDistributionGenerator & generator, const BeamData& beam, ParticleBunchFilter* filter = nullptr);
 
 	/**
 	*	Returns the total charge (in units of e).

--- a/Merlin/ParticleBunchConstructor.h
+++ b/Merlin/ParticleBunchConstructor.h
@@ -34,6 +34,8 @@ typedef enum {normalDistribution,flatDistribution,ringDistribution,skewHaloDistr
              } DistributionType;
 
 /**
+* Note this class is deprecated and should no longer be used. See \ref APIChanges .
+*
 * Constructs a particle bunch with random particles taken
 * from a 6D distribution. The phase space moments are
 * supplied as a BeamData struct. The form of the
@@ -55,6 +57,7 @@ public:
 	* Constructor taking the beam data and the number of
 	* particles to generate.
 	*/
+	[[deprecated("Use the ParticleBunch constructor directly.")]]
 	ParticleBunchConstructor (const BeamData& beam, size_t npart, DistributionType dist = normalDistribution);
 
 	~ParticleBunchConstructor ();

--- a/Merlin/ParticleDistributionGenerator.cpp
+++ b/Merlin/ParticleDistributionGenerator.cpp
@@ -1,11 +1,8 @@
 #include "ParticleDistributionGenerator.h"
-#include "RandomNG.h"
+
 #include "NumericalConstants.h"
 
-inline double RandomGauss(double variance, double cutoff)
-{
-	return cutoff==0 ? RandomNG::normal(0,variance) :  RandomNG::normal(0,variance,cutoff);
-}
+
 
 PSvector NormalParticleDistributionGenerator::GenerateFromDistribution() const
 {

--- a/Merlin/ParticleDistributionGenerator.cpp
+++ b/Merlin/ParticleDistributionGenerator.cpp
@@ -1,0 +1,46 @@
+#include "ParticleDistributionGenerator.h"
+#include "RandomNG.h"
+#include "NumericalConstants.h"
+
+inline double RandomGauss(double variance, double cutoff)
+{
+	return cutoff==0 ? RandomNG::normal(0,variance) :  RandomNG::normal(0,variance,cutoff);
+}
+
+PSvector NormalParticleDistributionGenerator::GenerateFromDistribution() const
+{
+	PSvector p(0);
+	p.x()	= RandomGauss(1,cutoffs.x());
+	p.xp()	= RandomGauss(1,cutoffs.xp());
+	p.y()	= RandomGauss(1,cutoffs.y());
+	p.yp()	= RandomGauss(1,cutoffs.yp());
+	p.dp()	= RandomGauss(1,cutoffs.dp());
+	p.ct()	= RandomGauss(1,cutoffs.ct());
+	return p;
+}
+
+PSvector UniformParticleDistributionGenerator::GenerateFromDistribution() const
+{
+	PSvector p(0);
+	p.x()	= RandomNG::uniform(-1,1);
+	p.xp()	= RandomNG::uniform(-1,1);
+	p.y()	= RandomNG::uniform(-1,1);
+	p.yp()	= RandomNG::uniform(-1,1);
+	p.dp()	= RandomNG::uniform(-1,1);
+	p.ct()	= RandomNG::uniform(-1,1);
+	return p;
+}
+
+PSvector RingParticleDistributionGenerator::GenerateFromDistribution() const
+{
+	PSvector p(0);
+	double u = RandomNG::uniform(-pi,pi);
+	p.x()	= cos(u);
+	p.xp()	= sin(u);
+	u = RandomNG::uniform(-pi,pi);
+	p.y()	= cos(u);
+	p.yp()	= sin(u);
+	p.dp()	= RandomNG::uniform(-1,1);
+	p.ct()	= RandomNG::uniform(-1,1);
+	return p;
+}

--- a/Merlin/ParticleDistributionGenerator.h
+++ b/Merlin/ParticleDistributionGenerator.h
@@ -1,0 +1,64 @@
+#ifndef ParticleDistributionGenerator_h
+#define ParticleDistributionGenerator_h 1
+
+#include "PSvector.h"
+
+/**
+* Base class for distribution generators. These can be used by
+* ParticleTracking::ParticleBunch::ParticleBunch to construct bunches with
+* a given distribution.
+*
+* Derived classes must override GenerateFromDistribution(), with a function
+* that returns a single PSvector from the distribution.
+*
+*  Additional parameters can be passed to the constructors of derived classes.
+*/
+class ParticleDistributionGenerator
+{
+public:
+	/**
+	 * Returns a single PSvector from the distribution
+	 */
+	virtual PSvector GenerateFromDistribution() const = 0;
+	virtual ~ParticleDistributionGenerator() {};
+};
+
+/**
+ * Generator for a normal (Gaussian) distribution.
+ */
+class NormalParticleDistributionGenerator: public ParticleDistributionGenerator
+{
+public:
+	/**
+	 * @param cutoffs_ Vector of cut off points in the distribution in each coordinate.
+	 * Default zero gives no cut off.
+	 */
+	NormalParticleDistributionGenerator(PSvector cutoffs_ = PSvector(0)): cutoffs(cutoffs_) {};
+	/**
+	 * @param cutoff Cut off point in distribution, same in each coordinate
+	 */
+	NormalParticleDistributionGenerator(double cutoff): cutoffs(PSvector(cutoff)) {};
+	virtual PSvector GenerateFromDistribution() const override;
+private:
+	PSvector cutoffs;
+};
+
+/**
+ * Generator for a uniform (flat) distribution.
+ */
+class UniformParticleDistributionGenerator: public ParticleDistributionGenerator
+{
+public:
+	virtual PSvector GenerateFromDistribution() const override;
+};
+
+/**
+ * Generator for a ring distribution.
+ */
+class RingParticleDistributionGenerator: public ParticleDistributionGenerator
+{
+public:
+	virtual PSvector GenerateFromDistribution() const override;
+};
+
+#endif

--- a/Merlin/ParticleDistributionGenerator.h
+++ b/Merlin/ParticleDistributionGenerator.h
@@ -2,6 +2,12 @@
 #define ParticleDistributionGenerator_h 1
 
 #include "PSvector.h"
+#include "RandomNG.h"
+
+inline double RandomGauss(double variance, double cutoff)
+{
+	return cutoff==0 ? RandomNG::normal(0,variance) :  RandomNG::normal(0,variance,cutoff);
+}
 
 /**
 * Base class for distribution generators. These can be used by

--- a/Merlin/ProtonBunch.h
+++ b/Merlin/ProtonBunch.h
@@ -53,7 +53,7 @@ public:
 		SetUpProfiling();
 	};
 
-	ProtonBunch (size_t np, const ParticleDistributionGenerator & generator, const BeamData& beam, ParticleBunchFilter* filter)
+	ProtonBunch (size_t np, const ParticleDistributionGenerator & generator, const BeamData& beam, ParticleBunchFilter* filter = nullptr)
 		:ParticleBunch(np, generator, beam, filter), GotElastic(false),GotDiffractive(false)
 	{
 		SetUpProfiling();

--- a/Merlin/ProtonBunch.h
+++ b/Merlin/ProtonBunch.h
@@ -53,6 +53,11 @@ public:
 		SetUpProfiling();
 	};
 
+	ProtonBunch (size_t np, const ParticleDistributionGenerator & generator, const BeamData& beam, ParticleBunchFilter* filter)
+		:ParticleBunch(np, generator, beam, filter), GotElastic(false),GotDiffractive(false)
+	{
+		SetUpProfiling();
+	}
 	// Proton Bunch Destructor
 	//~ProtonBunch(){delete ElasticScatter; delete DiffractiveScatter;};
 
@@ -110,7 +115,7 @@ public:
 	/**
 	* Select the Scattering physics mode
 	*/
-	enum scatMode { SixTrack , SixTrackIoniz , SixTrackElastic , SixTrackSD , Merlin };
+	enum scatMode { SixTrack, SixTrackIoniz, SixTrackElastic, SixTrackSD, Merlin };
 
 	void EnableScatteringPhysics(scatMode);
 	//void EnableSixtrackPhysics(bool);

--- a/MerlinTests/BasicTests/particle_bunch_constructor_test.cpp
+++ b/MerlinTests/BasicTests/particle_bunch_constructor_test.cpp
@@ -225,7 +225,7 @@ int main(int argc, char* argv[])
 
 			cout << "Dist: " << name << endl;
 
-			ParticleBunch* myBunch = new ParticleBunch(beam.p0, beam.charge, npart, *dist_type, beam);
+			ParticleBunch* myBunch = new ParticleBunch(npart, *dist_type, beam);
 
 			if(name == string("normal_cent"))
 			{

--- a/MerlinTests/ScatteringTests/lhc_collimation_test.cpp
+++ b/MerlinTests/ScatteringTests/lhc_collimation_test.cpp
@@ -8,7 +8,9 @@
 #include <ctime>
 
 
-#include "ParticleBunchConstructor.h"
+#include "ParticleDistributionGenerator.h"
+#include "HaloParticleDistributionGenerator.h"
+#include "BunchFilter.h"
 #include "ParticleTracker.h"
 #include "ParticleBunchTypes.h"
 #include "MADInterface.h"
@@ -281,21 +283,7 @@ int main(int argc, char* argv[])
 	delete disp;
 
 	//	BUNCH SETTINGS
-	ProtonBunch* myBunch;
 	int node_particles = npart;
-
-	ParticleBunchConstructor* constructor;
-	// dist 1 is halo in 1 plane, zero in other
-	// dist 2 is halo in 1 plane, gauss in other
-	switch (loss_map_mode)
-	{
-	case HORIZONTAL_LOSS:
-		constructor = new ParticleBunchConstructor(mybeam,node_particles,horizontalHaloDistribution2);
-		break;
-	case VERTICAL_LOSS:
-		constructor = new ParticleBunchConstructor(mybeam,node_particles,verticalHaloDistribution2);
-		break;
-	}
 
 	vector<Collimator*> TCP;
 	int siz = model->ExtractTypedElements(TCP,start_element);
@@ -317,10 +305,19 @@ int main(int argc, char* argv[])
 	HorizontalHaloParticleBunchFilter *hFilter = new HorizontalHaloParticleBunchFilter();
 	hFilter->SetHorizontalLimit(JawPosition);
 	hFilter->SetHorizontalOrbit(h_offset);
-	constructor->SetFilter(hFilter);
 
-	myBunch = constructor->ConstructParticleBunch<ProtonBunch>();
-	delete constructor;
+	// dist 1 is halo in 1 plane, zero in other
+	// dist 2 is halo in 1 plane, gauss in other
+	ProtonBunch* myBunch;
+	switch (loss_map_mode)
+	{
+	case HORIZONTAL_LOSS:
+		myBunch = new ProtonBunch(node_particles, HorizonalHalo2ParticleDistributionGenerator(), mybeam, hFilter);
+		break;
+	case VERTICAL_LOSS:
+		myBunch = new ProtonBunch(node_particles, VerticalHalo2ParticleDistributionGenerator(), mybeam, hFilter);
+		break;
+	}
 
 	myBunch->SetMacroParticleCharge(mybeam.charge);
 

--- a/doxygen/pages/APIChanges.md
+++ b/doxygen/pages/APIChanges.md
@@ -9,6 +9,40 @@ user programs.
 
 ## Version 5.02 {#APIChanges502}
 
+### Removal of ParticleBunchConstructor
+
+The ParticleBunchConstructor has been removed and its functionality moved into the constructor of the ParticleBunch class. This simplifies creating bunches and makes it easy to add new distribution types.
+
+For example the previous use of ParticleBunchConstructor:
+
+    ParticleBunchConstructor* constructor = new ParticleBunchConstructor(mybeam, npart, normalDistribution());
+    ProtonBunch* myBunch = constructor->ConstructParticleBunch<ProtonBunch>();
+
+can be replaced by:
+
+    ProtonBunch* myBunch = new ProtonBunch(npart, NormalParticleDistributionGenerator(), mybeamm);
+
+Where the distribution type was previously set by an enumeration, it is now set by passing a ParticleDistributionGenerator. The equivalents are:
+
+    normalDistribution              ->   NormalParticleDistributionGenerator()
+    flatDistribution                ->   UniformParticleDistributionGenerator()
+    ringDistribution                ->   RingParticleDistributionGenerator()
+    skewHaloDistribution            ->   RingParticleDistributionGenerator()
+    horizontalHaloDistribution1     ->   HorizonalHalo1ParticleDistributionGenerator()
+    verticalHaloDistribution1       ->   VerticalHalo1ParticleDistributionGenerator()
+    horizontalHaloDistribution2     ->   HorizonalHalo2ParticleDistributionGenerator()
+    verticalHaloDistribution2       ->   VerticalHalo2ParticleDistributionGenerator()
+
+Instead of using ParticleBunchConstructor::SetFilter(), filters can be passed into ParticleBunch:
+
+    ParticleBunch myBunch(npart, UniformParticleDistributionGenerator(), mybeamm, myfilter);
+
+Additional options beyond the scope of BeamData can be passed as arguments to the ParticleDistributionGenerator. For example 3 sigma cuts in the normal distribution:
+
+    NormalParticleDistributionGenerator(3.0);
+
+See ParticleTracking::ParticleBunch, ParticleDistributionGenerator
+
 ### Indecies -> Indexes
 
 The spelling of several function names was changed:


### PR DESCRIPTION
This puts all the features of ParticleBunchConstructor into a constructor for ParticleBunch. ParticleBunchConstructor is marked as deprecated (though not removed yet).

23bea6f Cleanup ParticleBunch() constructors
d78a2a9 Add ParticleDistributionGenerator and new ParticleBunch constructor
1cca9c8 Make ParticleBunch::SetCentroid enforce the zeroth particle is centroid
aaaaabb Use forward declarations instead of includes
7a6e7f0 Add HaloParticleDistributionGenerators
8a79004 Update particle_bunch_constructor_test
5e99be6 Additional checks for halo bunches
274ff20 Simplify new constructor using values from beam
117cc4a New constructor for bunch types
e4c4998 Document API change and deprecate old PBC
04b6450 Update lhc_collimation_test to new API