### PR TITLE
Make git pre-commit hook check staged files

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -10,21 +10,21 @@ BAD_FILES=""
 
 for FILE in $FILES;
 do
-	if ! $STYLE_SCRIPT check $FILE
+	if ! git show :$FILE | $STYLE_SCRIPT check -
 	then 
-		echo $FILE "failed style check"
+		echo "Staged version of" $FILE "failed style check"
 		BAD_FILES="$BAD_FILES $FILE"
 	fi
 done
 
 if [ -n "$BAD_FILES" ]
 then
-	echo "To see require changes run:"
+	echo -e "\nTo see require changes run:"
 	echo $STYLE_SCRIPT diff $BAD_FILES
-	echo "To fix:"
+	echo -e "\nTo fix:"
 	echo $STYLE_SCRIPT fix $BAD_FILES
 	echo git add $BAD_FILES
-	echo "Or bypass check with 'git commit --no-verify'"
+	echo -e "\nOr bypass check with 'git commit --no-verify'"
 	exit 1
 fi
 

--- a/tools/style_wrapper.py
+++ b/tools/style_wrapper.py
@@ -83,8 +83,21 @@ def indent_comment_like_eclipse(in_text):
 if __name__ == "__main__":
 	all_good = True
 	mode = sys.argv[1]
-	for fname in sys.argv[2:]:
-		in_text = open(fname, **enc_arg).read()
+	fnames = sys.argv[2:]
+
+	if "-" in fnames:
+		if mode == "fix":
+			print("Cannot use fix mode with input on stdin")
+			exit(2)
+		if len(fnames) > 1:
+			print("Can only accept a single file on stdin")
+			exit(2)
+
+	for fname in fnames:
+		if fname == "-":
+			in_text = sys.stdin.read()
+		else:
+			in_text = open(fname, **enc_arg).read()
 		out_text = in_text
 		#print(fname)
 		for func in format_functions:
@@ -93,7 +106,10 @@ if __name__ == "__main__":
 
 		if mode == "check":
 			if in_text != out_text:
-				print(fname, "needs reformatting")
+				if fname == "-":
+					print("stdin needs reformatting")
+				else:
+					print(fname, "needs reformatting")
 				all_good = False
 		elif mode == "diff":
 			if in_text != out_text:


### PR DESCRIPTION
This should reduce the problem of fixing style issues but missing the
step of adding them back into the commit.

The commit hook must be copied to the .git/hooks directory:

cp tools/pre-commit .git/hooks/

style_wrapper.py gains the ability to read from stdin, e.g.:

tools/style_wrapper.py check - < Merlin/MerlinVersion.h