### PR TITLE
LatticeFunctionTable SetForceLongitudinalStability

### DIFF
--- a/Merlin/DataTable.cpp
+++ b/Merlin/DataTable.cpp
@@ -79,9 +79,33 @@ void DataTable::ApertureFromRow(DataTableRow dtrow,size_t row)
 	this->Set_d("APER_4",row,dtrow.Get_d("APER_4"));
 }
 
+DataTable::location DataTable::get_location(const std::string &col_name) const
+{
+	try
+	{
+		return lookup.at(col_name);
+	}
+	catch(std::out_of_range &e)
+	{
+		throw std::out_of_range("DataTable: Could not find column: " + col_name);
+	}
+}
+
+DataTable::location DataTable::get_hlocation(const std::string &hcol_name) const
+{
+	try
+	{
+		return hlookup.at(hcol_name);
+	}
+	catch(std::out_of_range &e)
+	{
+		throw std::out_of_range("DataTable: Could not find header column: " + hcol_name);
+	}
+}
+
 double DataTable::Get_d(const std::string col_name, size_t i) const
 {
-	location l = lookup.at(col_name);
+	location l = get_location(col_name);
 	if(l.type != 'd')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a double");
@@ -91,7 +115,7 @@ double DataTable::Get_d(const std::string col_name, size_t i) const
 
 int DataTable::Get_i(const std::string col_name, size_t i) const
 {
-	location l = lookup.at(col_name);
+	location l = get_location(col_name);
 	if(l.type != 'i')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a int");
@@ -101,7 +125,7 @@ int DataTable::Get_i(const std::string col_name, size_t i) const
 
 std::string DataTable::Get_s(const std::string col_name, size_t i) const
 {
-	location l = lookup.at(col_name);
+	location l = get_location(col_name);
 	if(l.type != 's')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a string");
@@ -111,7 +135,7 @@ std::string DataTable::Get_s(const std::string col_name, size_t i) const
 
 void DataTable::Set(const std::string col_name, size_t i, double x)
 {
-	location l = lookup.at(col_name);
+	location l = get_location(col_name);
 	if(l.type != 'd')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a double");
@@ -121,7 +145,7 @@ void DataTable::Set(const std::string col_name, size_t i, double x)
 
 void DataTable::Set(const std::string col_name, size_t i, int x)
 {
-	location l = lookup.at(col_name);
+	location l = get_location(col_name);
 	if(l.type != 'i')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a int");
@@ -131,7 +155,7 @@ void DataTable::Set(const std::string col_name, size_t i, int x)
 
 void DataTable::Set(const std::string col_name, size_t i, std::string x)
 {
-	location l = lookup.at(col_name);
+	location l = get_location(col_name);
 	if(l.type != 's')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a string");
@@ -141,7 +165,7 @@ void DataTable::Set(const std::string col_name, size_t i, std::string x)
 
 void DataTable::SetWithStr(const std::string col_name, size_t i, std::string x)
 {
-	location l = lookup.at(col_name);
+	location l = get_location(col_name);
 	switch(l.type)
 	{
 	case 'd':
@@ -160,7 +184,7 @@ void DataTable::SetWithStr(const std::string col_name, size_t i, std::string x)
 
 std::string DataTable::GetAsStr(const std::string col_name, size_t i) const
 {
-	location l = lookup.at(col_name);
+	location l = get_location(col_name);
 	switch(l.type)
 	{
 	case 'd':
@@ -213,7 +237,7 @@ void DataTable::HeaderAddColumn(std::string col_name, char type)
 
 double DataTable::HeaderGet_d(const std::string col_name) const
 {
-	location l = hlookup.at(col_name);
+	location l = get_hlocation(col_name);
 	if(l.type != 'd')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a double");
@@ -223,7 +247,7 @@ double DataTable::HeaderGet_d(const std::string col_name) const
 
 int DataTable::HeaderGet_i(const std::string col_name) const
 {
-	location l = hlookup.at(col_name);
+	location l = get_hlocation(col_name);
 	if(l.type != 'i')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a int");
@@ -233,7 +257,7 @@ int DataTable::HeaderGet_i(const std::string col_name) const
 
 std::string DataTable::HeaderGet_s(const std::string col_name) const
 {
-	location l = hlookup.at(col_name);
+	location l = get_hlocation(col_name);
 	if(l.type != 's')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a string");
@@ -243,7 +267,7 @@ std::string DataTable::HeaderGet_s(const std::string col_name) const
 
 void DataTable::HeaderSet(const std::string col_name, double x)
 {
-	location l = hlookup.at(col_name);
+	location l = get_hlocation(col_name);
 	if(l.type != 'd')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a double");
@@ -253,7 +277,7 @@ void DataTable::HeaderSet(const std::string col_name, double x)
 
 void DataTable::HeaderSet(const std::string col_name, int x)
 {
-	location l = hlookup.at(col_name);
+	location l = get_hlocation(col_name);
 	if(l.type != 'i')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a int");
@@ -263,7 +287,7 @@ void DataTable::HeaderSet(const std::string col_name, int x)
 
 void DataTable::HeaderSet(const std::string col_name, std::string x)
 {
-	location l = hlookup.at(col_name);
+	location l = get_hlocation(col_name);
 	if(l.type != 's')
 	{
 		throw WrongTypeException("Column '" + col_name + "' is not a string");
@@ -273,7 +297,7 @@ void DataTable::HeaderSet(const std::string col_name, std::string x)
 
 void DataTable::HeaderSetWithStr(const std::string col_name, std::string x)
 {
-	location l = hlookup.at(col_name);
+	location l = get_hlocation(col_name);
 	switch(l.type)
 	{
 	case 'd':
@@ -292,7 +316,7 @@ void DataTable::HeaderSetWithStr(const std::string col_name, std::string x)
 
 std::string DataTable::HeaderGetAsStr(const std::string col_name) const
 {
-	location l = hlookup.at(col_name);
+	location l = get_hlocation(col_name);
 	switch(l.type)
 	{
 	case 'd':

--- a/Merlin/DataTable.h
+++ b/Merlin/DataTable.h
@@ -72,12 +72,16 @@ protected:
 	std::unordered_map<std::string, location> lookup;
 	size_t length;
 
+	location get_location(const std::string &col_name) const;
+
 	// Header values
 	std::vector<double> hdata_d;
 	std::vector<int> hdata_i;
 	std::vector<std::string> hdata_s;
 	std::vector<std::string> hcol_names;
 	std::unordered_map<std::string, location> hlookup;
+
+	location get_hlocation(const std::string &col_name) const;
 
 public:
 	/// Construct an empty DataTable.

--- a/Merlin/LatticeFunctions.h
+++ b/Merlin/LatticeFunctions.h
@@ -50,7 +50,7 @@ public:
 	void SetDelta(double new_delta);
 	void MakeTMSymplectic(bool flag);
 	int NumberOfRows();
-	[[deprecated("Use the SetForceLongitudinalStability() option.")]]
+	[[gnu::deprecated("Use the SetForceLongitudinalStability() option.")]]
 	void ScaleBendPathLength(double scale);
 
 	/** \brief Force longitudinal stability

--- a/Merlin/LatticeFunctions.h
+++ b/Merlin/LatticeFunctions.h
@@ -51,6 +51,16 @@ public:
 	void MakeTMSymplectic(bool flag);
 	int NumberOfRows();
 	void ScaleBendPathLength(double scale);
+
+	/** \brief Force longitudinal stability
+	 *
+	 * For lattices with no RF this can be used to force the longitudinal
+	 * block of the transfer matrix to be stable by setting R_55 to just
+	 * below 1.
+	 *
+	 * This only effects LatticeFunction calculations, not any other tracking.
+	 */
+	void SetForceLongitudinalStability(bool enable = true);
 	double Mean(int i, int j, int k, int n1 = 0, int n2 = -1);
 	double RMS(int i, int j, int k, int n1 = 0, int n2 = -1);
 
@@ -61,6 +71,7 @@ private:
 	double bendscale;
 	bool symplectify;
 	bool orbitonly;
+	bool forcelongstab = false;
 
 	vectorlfn lfnlist;
 

--- a/Merlin/LatticeFunctions.h
+++ b/Merlin/LatticeFunctions.h
@@ -50,6 +50,7 @@ public:
 	void SetDelta(double new_delta);
 	void MakeTMSymplectic(bool flag);
 	int NumberOfRows();
+	[[deprecated("Use the SetForceLongitudinalStability() option.")]]
 	void ScaleBendPathLength(double scale);
 
 	/** \brief Force longitudinal stability

--- a/Merlin/ParticleBunchConstructor.h
+++ b/Merlin/ParticleBunchConstructor.h
@@ -58,8 +58,8 @@ public:
 	 * Constructor taking the beam data and the number of
 	 * particles to generate.
 	 */
-	[[deprecated("Use the ParticleBunch constructor directly.")]] ParticleBunchConstructor(const BeamData& beam, size_t
-		npart, DistributionType dist = normalDistribution);
+	[[gnu::deprecated("Use the ParticleBunch constructor directly.")]] ParticleBunchConstructor(const BeamData& beam,
+		size_t npart, DistributionType dist = normalDistribution);
 
 	~ParticleBunchConstructor();
 

--- a/Merlin/RingDeltaTProcess.h
+++ b/Merlin/RingDeltaTProcess.h
@@ -16,6 +16,12 @@
 namespace ParticleTracking
 {
 
+/** \brief Should not be used in new code
+ *
+ * Old method for forcing longitudinal stability in order to calculate
+ * lattice functions. LatticeFunctionTable now offers a SetForceLongitudinalStability()
+ * option that should be used instead. This class will be deprecated in the future.
+ */
 class RingDeltaTProcess: public ParticleBunchProcess
 {
 public:

--- a/MerlinDocumentation/pages/APIChanges.md
+++ b/MerlinDocumentation/pages/APIChanges.md
@@ -9,6 +9,16 @@ user programs.
 
 ## Version 5.02 {#APIChanges502}
 
+### Deprecation of ScaleBendPathLength and RingDeltaTProcess
+
+For lattices with no RF the longitudinal part of the transfer matrix will be unstable, which prevents LatticeFunctionTable calculations from working. Previously by setting a bend scale, RingDeltaTProcess was used to adjust the ct particle coordinate make the dynamics stable. This however required finding a value of the bend scale that would work for a given lattice.
+
+This has now been replaced by a simpler option.
+
+LatticeFunctionTable::SetForceLongitudinalStability();
+
+This achieves the same by directly changing the R_55 transfer matrix element.
+
 ### RandomNG changes
 
 RandomNG has switched from using the internal ACG random number generator to the Mersenne Twister algorithm found in the C++11 standard library. There are only minor changes to the RandomNG api.

--- a/MerlinDocumentation/pages/APIChanges.md
+++ b/MerlinDocumentation/pages/APIChanges.md
@@ -9,6 +9,11 @@ user programs.
 
 ## Version 5.02 {#APIChanges502}
 
+### Behaviour change in LatticeFunctionTable
+
+Behaviour of calling LatticeFunctionTable::Calculate() has changed in the case where the longitudinal motion is unstable (for example lattices without RF). Previously it would return a table, but some of the values would be invalid (NaN). Now it will throw a MerlinException if you try to calculate a function using non transverse terms. If you were previously checking the content of the table for NaNs, you should now use a try/catch block to catch the error. Also see LatticeFunctionTable::SetForceLongitudinalStability() which can simplify the process of dealing with lattices without RF.
+
+
 ### Deprecation of ScaleBendPathLength and RingDeltaTProcess
 
 For lattices with no RF the longitudinal part of the transfer matrix will be unstable, which prevents LatticeFunctionTable calculations from working. Previously by setting a bend scale, RingDeltaTProcess was used to adjust the ct particle coordinate make the dynamics stable. This however required finding a value of the bend scale that would work for a given lattice.

--- a/MerlinTests/OpticsTests/lhc_optics_test.cpp
+++ b/MerlinTests/OpticsTests/lhc_optics_test.cpp
@@ -7,13 +7,14 @@
 
 #include "../tests.h"
 #include <iostream>
-#include <sstream>
 #include <string>
+#include <vector>
 #include <iomanip>
 
 #include "MADInterface.h"
 #include "LatticeFunctions.h"
-#include "AcceleratorModel.h"
+#include "DataTable.h"
+#include "DataTableTFS.h"
 
 /* Read a TFS lattice with the MAD interface, measure the twiss parameters with
  * LatticeFunctionTable. Also read the data from the TFS file
@@ -25,20 +26,8 @@
  * Note that MADInterface deliberately ignores some zero length elements
  */
 
-struct tfs_line
-{
-	string name;
-	string keyword;
-	double s, l;
-	double betx, bety, alfx, alfy;
-	double k0l, k1l, k2l, k3l, k4l;
-
-};
-
-inline string StripQuotes(const string& text)
-{
-	return text.substr(1, text.length() - 2);
-}
+const vector<string> skip_types{"DRIFT", "RCOLLIMATOR", "INSTRUMENT", "TKICKER", "PLACEHOLDER", "VMONITOR", "HMONITOR",
+								"KICKER", "MATRIX"};
 
 bool check_diff(double x1, double x2, double da, double dr)
 {
@@ -85,130 +74,7 @@ int main(int argc, char* argv[])
 	twiss_table->AddFunction(4, 6, 3);
 	twiss_table->AddFunction(6, 6, 3);
 
-	// read twiss parameters from the lattice file
-	vector<tfs_line> tfs_table;
-	ifstream tfs_file(lattice_path.c_str());
-	string line;
-	string dummy;
-	while(getline(tfs_file, line))
-	{
-		while(line.length() > 0 && line[0] == ' ')
-		{
-			line = line.substr(1, line.length() - 1);
-		}
-		if(line == "")
-		{
-			continue;
-		}
-		if(line[0] == '@' || line[0] == '*' || line[0] == '$')
-		{
-			continue;
-		}
-		istringstream liness(line);
-		tfs_line this_line;
-		//(0, 'NAME'), (1, 'KEYWORD'), (2, 'S'), (3, 'L'), (4, 'KS'), (5, 'KSL'), (6, 'K0L'), (7, 'K1L'), (8, 'K2L'), (9, 'K3L'), (10, 'K4L'), (11, 'K1S'), (12, 'K2S'), (13, 'K3S'), (14, 'K4S'), (15, 'HKICK'), (16, 'VKICK'), (17, 'BETX'), (18, 'BETY'), (19, 'ALFX'), (20, 'ALFY'), (21, 'MUX'), (22, 'MUY'), (23, 'DX'), (24, 'DY'), (25, 'DPX'), (26, 'DPY'), (27, 'R11'), (28, 'R12'), (29, 'R22'), (30, 'R21'), (31, 'X'), (32, 'PX'), (33, 'Y'), (34, 'PY'), (35, 'T'), (36, 'DELTAP'), (37, 'VOLT'), (38, 'LAG'), (39, 'HARMON'), (40, 'FREQ'), (41, 'E1'), (42, 'E2'), (43, 'APERTYPE'), (44, 'APER_1'), (45, 'APER_2'), (46, 'APER_3'), (47, 'APER_4'), (48, 'TILT'), (49, 'ANGLE'), (50, 'ASSEMBLY_ID'), (51, 'MECH_SEP')
-		for(int i = 0; i < 52; i++)
-		{
-			switch(i)
-			{
-			case 0:
-				liness >> this_line.name;
-				this_line.name = StripQuotes(this_line.name);
-				break;
-			case 1:
-				liness >> this_line.keyword;
-				this_line.keyword = StripQuotes(this_line.keyword);
-				break;
-			case 2:
-				liness >> this_line.s;
-				break;
-			case 3:
-				liness >> this_line.l;
-				break;
-			case 6:
-				liness >> this_line.k0l;
-				break;
-			case 7:
-				liness >> this_line.k1l;
-				break;
-			case 8:
-				liness >> this_line.k2l;
-				break;
-			case 9:
-				liness >> this_line.k3l;
-				break;
-			case 10:
-				liness >> this_line.k4l;
-				break;
-			case 17:
-				liness >> this_line.betx;
-				break;
-			case 18:
-				liness >> this_line.bety;
-				break;
-			case 19:
-				liness >> this_line.alfx;
-				break;
-			case 20:
-				liness >> this_line.alfy;
-				break;
-			default:
-				liness >> dummy;
-				break;
-
-			}
-		}
-		//liness >> this_line.name >> this_line.keyword;
-		// Mimic MAD interface ignoring certain elements
-		if(this_line.keyword == "MULTIPOLE")
-		{
-			if(this_line.k0l != 0)
-			{
-				this_line.keyword = "SBEND";
-			}
-			else if(this_line.k1l != 0)
-			{
-				this_line.keyword = "QUADRUPOLE";
-			}
-			else if(this_line.k2l != 0)
-			{
-				this_line.keyword = "SEXTUPOLE";
-			}
-			else if(this_line.k3l != 0)
-			{
-				this_line.keyword = "OCTUPOLE";
-			}
-			else if(this_line.k4l != 0)
-			{
-				this_line.keyword = "DECAPOLE";
-			}
-			else
-			{
-				this_line.keyword = "DRIFT";
-			}
-		}
-		if(this_line.keyword == "INSTRUMENT")
-		{
-			this_line.keyword = "DRIFT";
-		}
-		if(this_line.keyword == "TKICKER")
-		{
-			this_line.keyword = "DRIFT";
-		}
-		if(this_line.keyword == "PLACEHOLDER")
-		{
-			this_line.keyword = "DRIFT";
-		}
-
-		if((this_line.keyword == "RCOLLIMATOR" ||
-			this_line.keyword == "DRIFT")
-			&& this_line.l == 0)
-		{
-			continue;
-		}
-
-		tfs_table.push_back(this_line);
-	}
+	unique_ptr<DataTable> mad_optics(DataTableReaderTFS(lattice_path).Read());
 
 	double bscale1 = 1e-22;
 
@@ -235,77 +101,119 @@ int main(int argc, char* argv[])
 		}
 	}
 
-	/*AddFunction(1,0,0); // closed orbit: x
-	 *     AddFunction(2,0,0); // closed orbit: px
-	 *     AddFunction(3,0,0); // closed orbit: y
-	 *     AddFunction(4,0,0); // closed orbit: py
-	 *     AddFunction(5,0,0); // closed orbit: ct
-	 *     AddFunction(6,0,0); // closed orbit: dp
-	 *     AddFunction(1,1,1); // beta_x
-	 *     AddFunction(1,2,1); // -alfa_x
-	 *     AddFunction(3,3,2); // beta_y
-	 *     AddFunction(3,4,2); // -alfa_y
-	 *                                     */
-
 	cout << setprecision(9);
 
-	size_t x = 0;
-	//double worst_betx = 0, worst_bety = 0, worst_alfx = 0, worst_alfy = 0;
-	//int worst_betx_n = 0, worst_bety_n = 0, worst_alfx_n = 0, worst_alfy_n = 0;
-	for(AcceleratorModel::BeamlineIterator bi = model->GetBeamline().begin(); bi != model->GetBeamline().end(); bi++)
+	size_t x = 0; // counter for lattice table
+	size_t xm = 0; // counter for mad tfs file
+	for(const auto &bi : model->GetBeamline())
 	{
-		AcceleratorComponent *ac = &(*bi)->GetComponent();
+		const AcceleratorComponent *ac = &(bi->GetComponent());
 		// twiss_table has params at start of element
-		// tfs has params at end, hence use tfs_table[x-1]
+		// tfs has params at end, hence use so compare to previous
+
 		if(x >= 1)
 		{
-			//cout << ac->GetName() << "\t" ;//<< twiss_table->Value(1,1,1,x) << " ";
-			//cout << tfs_table[x].name <<endl;//" " << tfs_table[x-1].betx << endl;
+			// Need to skip zero length DRIFTs and RCOLLIMATORs, as these get dropped by madinterface
+			// so xm get extra increments
+			while(true)
+			{
+				if(mad_optics->Get_d("L", xm) != 0)
+					break;
+				string mad_el_type = mad_optics->Get_s("KEYWORD", xm);
+				if(mad_el_type == "MULTIPOLE" && mad_optics->Get_d("K0L", xm) == 0
+					&& mad_optics->Get_d("K1L", xm) == 0
+					&& mad_optics->Get_d("K2L", xm) == 0
+					&& mad_optics->Get_d("K3L", xm) == 0
+					&& mad_optics->Get_d("K4L", xm) == 0
+					)
+				{
+					mad_el_type = "DRIFT";
+				}
+
+				if(none_of(skip_types.begin(), skip_types.end(), [&mad_el_type](const string st){
+					return st == mad_el_type;
+				}))
+					break;
+				xm++;
+			}
 
 			// check that we are on the correct element. (BPMs get there name manged, so ignore them)
-			if(ac->GetName() != tfs_table[x].name && tfs_table[x].name.substr(0, 3) != "BPM")
+			if(ac->GetName() != mad_optics->Get_s("NAME", xm) && mad_optics->Get_s("NAME", xm).substr(0, 3) != "BPM")
 			{
-				cout << "Names do not match at:" << x << " " << ac->GetName() << " != " << tfs_table[x].name << endl;
+				cout << "Names do not match at:" << x << " " << ac->GetName() << " != " << mad_optics->Get_s("NAME",
+					x) << endl;
 				exit(1);
 			}
 
-			//cout << ac->GetName() << "\t" << twiss_table->Value(1,2,1,x) << " " << tfs_table[x-1].alfx << endl;
-			// check params
-
-			if(!check_diff(twiss_table->Value(1, 1, 1, x), tfs_table[x - 1].betx, 5e-3, 1e-6))
+			if(!check_diff(twiss_table->Value(1, 1, 1, x), mad_optics->Get_d("BETX", xm - 1), 5e-3, 1e-6))
 			{
-				cout << "Beta_x does not match at:" << x << " " << tfs_table[x].name
-					 << " " << twiss_table->Value(1, 1, 1, x) << " != " << tfs_table[x - 1].betx << endl;
+				cout << "Beta_x does not match at:" << x << " " << mad_optics->Get_s("NAME", xm)
+					 << " " << twiss_table->Value(1, 1, 1, x) << " != " << mad_optics->Get_d("BETX", xm - 1) << endl;
 				exit(1);
 			}
 
-			if(!check_diff(twiss_table->Value(3, 3, 2, x), tfs_table[x - 1].bety, 1e-3, 1e-6))
+			if(!check_diff(twiss_table->Value(3, 3, 2, x), mad_optics->Get_d("BETY", xm - 1), 5e-3, 1e-6))
 			{
-				cout << "Beta_y does not match at:" << x << " " << tfs_table[x].name
-					 << " " << twiss_table->Value(3, 3, 2, x) << " != " << tfs_table[x - 1].bety << endl;
+				cout << "Beta_y does not match at:" << x << " " << mad_optics->Get_s("NAME", xm)
+					 << " " << twiss_table->Value(3, 3, 2, x) << " != " << mad_optics->Get_d("BETY", xm - 1) << endl;
 				exit(1);
 			}
 
-			if(!check_diff(-twiss_table->Value(1, 2, 1, x), tfs_table[x - 1].alfx, 1e-3, 1e-6))
+			if(!check_diff(-twiss_table->Value(1, 2, 1, x), mad_optics->Get_d("ALFX", xm - 1), 1e-3, 1e-6))
 			{
-				cout << "Alpha_x does not match at:" << x << " " << tfs_table[x].name
-					 << " " << -twiss_table->Value(1, 2, 1, x) << " != " << tfs_table[x - 1].alfx << endl;
+				cout << "Alpha_x does not match at:" << x << " " << mad_optics->Get_s("NAME", xm)
+					 << " " << -twiss_table->Value(1, 2, 1, x) << " != " << mad_optics->Get_d("ALFX", xm - 1) << endl;
 				exit(1);
 			}
 
-			if(!check_diff(-twiss_table->Value(3, 4, 2, x), tfs_table[x - 1].alfy, 1e-3, 1e-6))
+			if(!check_diff(-twiss_table->Value(3, 4, 2, x), mad_optics->Get_d("ALFY", xm - 1), 1e-3, 1e-6))
 			{
-				cout << "Alpha_y does not match at:" << x << " " << tfs_table[x].name
-					 << " " << -twiss_table->Value(3, 4, 2, x) << " != " << tfs_table[x - 1].alfy << endl;
+				cout << "Alpha_y does not match at:" << x << " " << mad_optics->Get_s("NAME", xm)
+					 << " " << -twiss_table->Value(3, 4, 2, x) << " != " << mad_optics->Get_d("ALFY", xm - 1) << endl;
 				exit(1);
 			}
 
+			if(!check_diff(twiss_table->Value(1, 6, 3, x) / twiss_table->Value(6, 6, 3, x), mad_optics->Get_d("DX", xm
+				- 1), 5e-3, 5e-2))
+			{
+				cout << "Disp_x does not match at:" << x << " " << mad_optics->Get_s("NAME", xm)
+					 << " " << twiss_table->Value(1, 6, 3, x) / twiss_table->Value(6, 6, 3, x) << " != "
+					 << mad_optics->Get_d("DX", xm - 1) << endl;
+				exit(1);
+			}
+
+			if(!check_diff(twiss_table->Value(2, 6, 3, x) / twiss_table->Value(6, 6, 3, x), mad_optics->Get_d("DPX",
+				xm - 1), 2e-3, 1e-2))
+			{
+				cout << "Disp_px does not match at:" << x << " " << mad_optics->Get_s("NAME", xm)
+					 << " " << twiss_table->Value(2, 6, 3, x) / twiss_table->Value(6, 6, 3, x) << " != "
+					 << mad_optics->Get_d("DPX", xm - 1) << endl;
+				exit(1);
+			}
+
+			if(!check_diff(twiss_table->Value(3, 6, 3, x) / twiss_table->Value(6, 6, 3, x), mad_optics->Get_d("DY", xm
+				- 1), 5e-3, 5e-2))
+			{
+				cout << "Disp_y does not match at:" << x << " " << mad_optics->Get_s("NAME", xm)
+					 << " " << twiss_table->Value(3, 6, 3, x) / twiss_table->Value(6, 6, 3, x) << " != "
+					 << mad_optics->Get_d("DY", xm - 1) << endl;
+				exit(1);
+			}
+
+			if(!check_diff(twiss_table->Value(4, 6, 3, x) / twiss_table->Value(6, 6, 3, x), mad_optics->Get_d("DPY",
+				xm - 1), 2e-3, 1e-2))
+			{
+				cout << "Disp_py does not match at:" << x << " " << mad_optics->Get_s("NAME", xm)
+					 << " " << twiss_table->Value(4, 6, 3, x) / twiss_table->Value(6, 6, 3, x) << " != "
+					 << mad_optics->Get_d("DPY", xm - 1) << endl;
+				exit(1);
+			}
 		}
 		x++;
+		xm++;
 	}
 
 	delete myMADinterface;
 	delete model;
 	delete twiss_table;
-
 }

--- a/MerlinTests/OpticsTests/lhc_optics_test.cpp
+++ b/MerlinTests/OpticsTests/lhc_optics_test.cpp
@@ -76,30 +76,8 @@ int main(int argc, char* argv[])
 
 	unique_ptr<DataTable> mad_optics(DataTableReaderTFS(lattice_path).Read());
 
-	double bscale1 = 1e-22;
-
-	while(true)
-	{
-		cout << "Trying bend scale: " << bscale1 << endl;
-		twiss_table->ScaleBendPathLength(bscale1);
-		try
-		{
-			twiss_table->Calculate();
-			cout << "Success!" << endl;
-			break;
-		}
-		catch(MerlinException &e)
-		{
-			cout << "Adjusting bend scale" << endl;
-			bscale1 *= 2;
-		}
-
-		if(bscale1 > 1e-18)
-		{
-			cout << "Giving up" << endl;
-			exit(1);
-		}
-	}
+	twiss_table->SetForceLongitudinalStability(true);
+	twiss_table->Calculate();
 
 	cout << setprecision(9);
 

--- a/MerlinTests/ScatteringTests/lhc_collimation_test.cpp
+++ b/MerlinTests/ScatteringTests/lhc_collimation_test.cpp
@@ -173,29 +173,8 @@ int main(int argc, char* argv[])
 	twiss->AddFunction(6, 6, 3);
 
 	// find twiss
-	double bscale1 = 1e-22;
-	while(true)
-	{
-		cout << "Trying bend scale: " << bscale1 << endl;
-		twiss->ScaleBendPathLength(bscale1);
-		try
-		{
-			twiss->Calculate();
-			cout << "Success!" << endl;
-			break;
-		}
-		catch(MerlinException &e)
-		{
-			cout << "Adjusting bend scale" << endl;
-			bscale1 *= 2;
-		}
-
-		if(bscale1 > 1e-18)
-		{
-			cout << "Giving up" << endl;
-			exit(1);
-		}
-	}
+	twiss->SetForceLongitudinalStability(true);
+	twiss->Calculate();
 
 	// FLAG to set an automatically matching between beam envelope and collimator taper
 	collimator_db->MatchBeamEnvelope(false);
@@ -377,10 +356,10 @@ int main(int argc, char* argv[])
 		tracker->AddProcess(myCollimateProcess);
 	}
 
-	//	TRACKING RUN
+	// TRACKING RUN
 	for(int turn = 1; turn <= nturns; turn++)
 	{
-   		cout << "Turn " << turn << "\tParticle number: " << myBunch->size() << endl;
+		cout << "Turn " << turn << "\tParticle number: " << myBunch->size() << endl;
 		tracker->Track(myBunch);
 		if(myBunch->size() <= 1)
 		{


### PR DESCRIPTION
Replace LatticeFunctionTable's bend scale options with a more reliable and explicit SetForceLongitudinalStability option.

7e5dcfe lhc_optics_test check dispersion
8e4f4be DataTable: Improve error message
999fbd1 LatticeFunctionTable: Add SetForceLongitudinalStability()
f9a08c9 Deprecate LatticeFunctionTable::ScaleBendPathLength()
0cb185c Stop using bend scale in tests
aad09bb Use gnu::deprecated to avoid clang warning
