### PR TITLE
Some aperture file reading fixes

### DIFF
--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, macOS-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-latest, macOS-latest, windows-latest]
         python-version: [3.9]
         build-type: [Release, Debug]
       fail-fast: false

--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -46,7 +46,7 @@ jobs:
       # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: |
-        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DPython3_ROOT_DIR=${pythonLocation}
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DPython3_ROOT_DIR=${Python3_ROOT_DIR}
         cat CMakeCache.txt
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
 endif()
 
 #Set the cmake version required
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 # Set the project name and options
 PROJECT(MERLIN)

--- a/DeveloperTools/CodeTesting/CMakeLists.txt
+++ b/DeveloperTools/CodeTesting/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(Python3_FIND_STRATEGY "LOCATION")
 find_package(Python3)
 
 # macro to install a test executable (need add_test() to call it)

--- a/DeveloperTools/Tools/uncrustify.conf
+++ b/DeveloperTools/Tools/uncrustify.conf
@@ -236,7 +236,7 @@ sp_after_cast                  = add        # { Ignore, Add, Remove, Force }
 sp_before_for_colon            = add        # { Ignore, Add, Remove, Force }
 
 # Controls the spaces before a trailing or embedded comment
-sp_before_tr_emb_cmt           = add        # { Ignore, Add, Remove, Force }
+sp_before_tr_cmt               = add        # { Ignore, Add, Remove, Force }
 
 # Don't split one-line enums: 'enum foo { BAR = 15 };'
 nl_enum_leave_one_liners       = false      # { False, True }

--- a/Merlin++/ApertureConfiguration.cpp
+++ b/Merlin++/ApertureConfiguration.cpp
@@ -46,10 +46,10 @@ ApertureConfiguration::ApertureConfiguration(string InputFileName)
 		if(itr.Get_d("APER_1") != 0 || itr.Get_d("APER_2") != 0 || itr.Get_d("APER_3") != 0 || itr.Get_d(
 				"APER_4") != 0)
 		{
-			ApertureDataTable.ApertureFromRow(itr, row);
+			ApertureDataTable.ApertureFromRow(itr);
 			ApertureDataTable.Set("S", row, (itr.Get_d("S") - itr.Get_d("L")));
 			++row;
-			ApertureDataTable.ApertureFromRow(itr, row);
+			ApertureDataTable.ApertureFromRow(itr);
 			++row;
 		}
 	}
@@ -115,19 +115,19 @@ void ApertureConfiguration::ConfigureElementApertures(AcceleratorModel* Model)
 				if(this_ap == ApertureDataTable.begin())
 				{
 					//get initial point, interpolate from last point
-					ThisElementAperture.ApertureFromRow(*last_ap, row);
+					ThisElementAperture.ApertureFromRow(*last_ap);
 					++row;
 				}
 				else
 				{
 					--this_ap;
-					ThisElementAperture.ApertureFromRow(*this_ap, row);
+					ThisElementAperture.ApertureFromRow(*this_ap);
 					++this_ap;
 				}
 				while((*this_ap).Get_d("S") <= (Position + ElementLength))
 				{
 					++row;
-					ThisElementAperture.ApertureFromRow(*this_ap, row);
+					ThisElementAperture.ApertureFromRow(*this_ap);
 					++this_ap;
 					if(this_ap == ApertureDataTable.end())
 					{
@@ -138,12 +138,12 @@ void ApertureConfiguration::ConfigureElementApertures(AcceleratorModel* Model)
 				{
 					++row;
 					this_ap = ApertureDataTable.begin();
-					ThisElementAperture.ApertureFromRow(*this_ap, row);
+					ThisElementAperture.ApertureFromRow(*this_ap);
 				}
 				else
 				{
 					++row;
-					ThisElementAperture.ApertureFromRow(*this_ap, row);
+					ThisElementAperture.ApertureFromRow(*this_ap);
 					this_ap = ApertureDataTable.end();
 				}
 
@@ -181,7 +181,7 @@ void ApertureConfiguration::ConfigureElementApertures(AcceleratorModel* Model)
 						--negcount;
 						continue;
 					}
-					CleanElementAperture.ApertureFromRow(itr, cleanit);
+					CleanElementAperture.ApertureFromRow(itr);
 					++cleanit;
 				}
 

--- a/Merlin++/ApertureConfiguration.cpp
+++ b/Merlin++/ApertureConfiguration.cpp
@@ -22,7 +22,16 @@ using namespace std;
 
 ApertureConfiguration::ApertureConfiguration(string InputFileName)
 {
-	auto dt = make_unique<DataTable>(DataTableReaderTFS(InputFileName).Read());
+	unique_ptr<DataTable> dt;
+	try
+	{
+		dt = make_unique<DataTable>(DataTableReaderTFS(InputFileName).Read());
+	}
+	catch(BadFormatException& e)
+	{
+		std::cerr << "ApertureConfiguration: Error reading " << InputFileName << std::endl;
+		throw;
+	}
 
 	ApertureDataTable.AddColumn("S", 'd');
 	ApertureDataTable.AddColumn("APER_1", 'd');

--- a/Merlin++/ApertureConfiguration.cpp
+++ b/Merlin++/ApertureConfiguration.cpp
@@ -40,17 +40,14 @@ ApertureConfiguration::ApertureConfiguration(string InputFileName)
 	ApertureDataTable.AddColumn("APER_4", 'd');
 	ApertureDataTable.AddColumn("APERTYPE", 's');
 	//filter non-aperture entries
-	size_t row = 0;
 	for(auto &itr : *dt)
 	{
 		if(itr.Get_d("APER_1") != 0 || itr.Get_d("APER_2") != 0 || itr.Get_d("APER_3") != 0 || itr.Get_d(
 				"APER_4") != 0)
 		{
 			ApertureDataTable.ApertureFromRow(itr);
-			ApertureDataTable.Set("S", row, (itr.Get_d("S") - itr.Get_d("L")));
-			++row;
+			ApertureDataTable.Set("S", ApertureDataTable.Length() - 1, (itr.Get_d("S") - itr.Get_d("L")));
 			ApertureDataTable.ApertureFromRow(itr);
-			++row;
 		}
 	}
 }
@@ -100,7 +97,6 @@ void ApertureConfiguration::ConfigureElementApertures(AcceleratorModel* Model)
 
 			while(this_ap != ApertureDataTable.end())
 			{
-				size_t row = 0;
 				DataTable ThisElementAperture;
 				DataTable CleanElementAperture;
 				ThisElementAperture.AddColumn("APERTYPE", 's');
@@ -116,7 +112,6 @@ void ApertureConfiguration::ConfigureElementApertures(AcceleratorModel* Model)
 				{
 					//get initial point, interpolate from last point
 					ThisElementAperture.ApertureFromRow(*last_ap);
-					++row;
 				}
 				else
 				{
@@ -126,7 +121,6 @@ void ApertureConfiguration::ConfigureElementApertures(AcceleratorModel* Model)
 				}
 				while((*this_ap).Get_d("S") <= (Position + ElementLength))
 				{
-					++row;
 					ThisElementAperture.ApertureFromRow(*this_ap);
 					++this_ap;
 					if(this_ap == ApertureDataTable.end())
@@ -136,13 +130,11 @@ void ApertureConfiguration::ConfigureElementApertures(AcceleratorModel* Model)
 				}
 				if(this_ap == ApertureDataTable.end())
 				{
-					++row;
 					this_ap = ApertureDataTable.begin();
 					ThisElementAperture.ApertureFromRow(*this_ap);
 				}
 				else
 				{
-					++row;
 					ThisElementAperture.ApertureFromRow(*this_ap);
 					this_ap = ApertureDataTable.end();
 				}
@@ -150,7 +142,6 @@ void ApertureConfiguration::ConfigureElementApertures(AcceleratorModel* Model)
 				//First do a little bit of cleaning
 				//If we have an entry at 0 (or very close to), and also an entry at negative values, we can discard the negative entry
 				size_t thisit = 0;
-				size_t cleanit = 0;
 				bool zeroentry = false;
 				size_t negcount = 0;
 
@@ -182,7 +173,6 @@ void ApertureConfiguration::ConfigureElementApertures(AcceleratorModel* Model)
 						continue;
 					}
 					CleanElementAperture.ApertureFromRow(itr);
-					++cleanit;
 				}
 
 				if(fequal(CleanElementAperture.Get_d("S", 0) - Position, 0.0, 5e-7))

--- a/Merlin++/DataTable.cpp
+++ b/Merlin++/DataTable.cpp
@@ -69,9 +69,9 @@ void DataTable::AddRowFromRow(DataTableRow dt)
 	//TODO
 }
 
-void DataTable::ApertureFromRow(DataTableRow dtrow, size_t row)
+void DataTable::ApertureFromRow(DataTableRow dtrow)
 {
-	this->AddRow();
+	auto row = this->AddRow();
 	this->Set("APERTYPE", row, dtrow.Get_s("APERTYPE"));
 	this->Set_d("S", row, dtrow.Get_d("S"));
 	this->Set_d("APER_1", row, dtrow.Get_d("APER_1"));

--- a/Merlin++/DataTable.h
+++ b/Merlin++/DataTable.h
@@ -102,7 +102,7 @@ public:
 	void AddRowFromRow(DataTableRow dt);
 
 	//configure aperture info from DataTableRow
-	void ApertureFromRow(DataTableRow dtrow, size_t row);
+	void ApertureFromRow(DataTableRow dtrow);
 
 	// get type in name
 	///Get double value by name and row.


### PR DESCRIPTION
Some issues were found when reading aperture files where the row numbers were not being incremented in all cases.

This can be solved by letting the DataTable keep track of the current row.

Also improve an error message, update uncrustify.conf and tweak the actions and cmake.